### PR TITLE
Support osx and other apps, not just iOS

### DIFF
--- a/SwiftDDP.podspec
+++ b/SwiftDDP.podspec
@@ -12,9 +12,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/siegesmund/SwiftDDP.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/psiegesmund'
 
-  # Attempt to be compatible on all platforms
-  # s.platform     = :ios, '8.0'
-
   s.requires_arc = true
 
   s.source_files = 'SwiftDDP/**/*.swift'

--- a/SwiftDDP.podspec
+++ b/SwiftDDP.podspec
@@ -14,9 +14,10 @@ Pod::Spec.new do |s|
 
   # Attempt to be compatible on all platforms
   # s.platform     = :ios, '8.0'
+
   s.requires_arc = true
 
-  s.source_files = 'SwiftDDP/**/*'
+  s.source_files = 'SwiftDDP/**/*.swift'
 
   s.dependency 'CryptoSwift'
   s.dependency 'SwiftWebSocket'

--- a/SwiftDDP.podspec
+++ b/SwiftDDP.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/siegesmund/SwiftDDP.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/psiegesmund'
 
-  s.platform     = :ios, '8.0'
+  # Attempt to be compatible on all platforms
+  # s.platform     = :ios, '8.0'
   s.requires_arc = true
 
   s.source_files = 'SwiftDDP/**/*'


### PR DESCRIPTION
The platform restriction to iOS 8.0 appears to be arbitrary. OS X would benefit from SwiftDDP as well, as could TVos and WatchOS.