### PR TITLE
Fix for timestamp to Date conversion on 32-bit architecture

### DIFF
--- a/SwiftDDP/DDPExtensions.swift
+++ b/SwiftDDP/DDPExtensions.swift
@@ -269,10 +269,8 @@ extension DDPClient {
                 if let data = result as? NSDictionary,
                     let id = data["id"] as? String,
                     let token = data["token"] as? String,
-                    let tokenExpires = data["tokenExpires"] as? NSDictionary,
-                    let date = tokenExpires["$date"] as? Double {
-                        let timestamp = NSTimeInterval(Double(date)) / 1000.0
-                        let expiration = NSDate(timeIntervalSince1970: timestamp)
+                    let tokenExpires = data["tokenExpires"] as? NSDictionary {
+                        let expiration = dateFromTimestamp(tokenExpires)
                         self.userData.setObject(id, forKey: DDP_ID)
                         self.userData.setObject(token, forKey: DDP_TOKEN)
                         self.userData.setObject(expiration, forKey: DDP_TOKEN_EXPIRES)
@@ -364,10 +362,8 @@ extension DDPClient {
                 if let data = result as? NSDictionary,
                     let id = data["id"] as? String,
                     let token = data["token"] as? String,
-                    let tokenExpires = data["tokenExpires"] as? NSDictionary,
-                    let date = tokenExpires["$date"] as? Double {
-                        let timestamp = NSTimeInterval(Double(date)) / 1000.0
-                        let expiration = NSDate(timeIntervalSince1970: timestamp)
+                    let tokenExpires = data["tokenExpires"] as? NSDictionary {
+                        let expiration = dateFromTimestamp(tokenExpires)
                         self.userData.setObject(id, forKey: DDP_ID)
                         self.userData.setObject(token, forKey: DDP_TOKEN)
                         self.userData.setObject(expiration, forKey: DDP_TOKEN_EXPIRES)

--- a/SwiftDDP/DDPExtensions.swift
+++ b/SwiftDDP/DDPExtensions.swift
@@ -270,7 +270,7 @@ extension DDPClient {
                     let id = data["id"] as? String,
                     let token = data["token"] as? String,
                     let tokenExpires = data["tokenExpires"] as? NSDictionary,
-                    let date = tokenExpires["$date"] as? Int {
+                    let date = tokenExpires["$date"] as? Double {
                         let timestamp = NSTimeInterval(Double(date)) / 1000.0
                         let expiration = NSDate(timeIntervalSince1970: timestamp)
                         self.userData.setObject(id, forKey: DDP_ID)
@@ -365,7 +365,7 @@ extension DDPClient {
                     let id = data["id"] as? String,
                     let token = data["token"] as? String,
                     let tokenExpires = data["tokenExpires"] as? NSDictionary,
-                    let date = tokenExpires["$date"] as? Int {
+                    let date = tokenExpires["$date"] as? Double {
                         let timestamp = NSTimeInterval(Double(date)) / 1000.0
                         let expiration = NSDate(timeIntervalSince1970: timestamp)
                         self.userData.setObject(id, forKey: DDP_ID)

--- a/SwiftDDP/DDPUtilities.swift
+++ b/SwiftDDP/DDPUtilities.swift
@@ -65,3 +65,11 @@ func getValue(fromUrl url: String, forArgument argument:String) -> String? {
     print("Arguments \(arguments) for url: \(url)")
     return arguments[argument]
 }
+
+// Misc
+
+func dateFromTimestamp(containedIn: NSDictionary) -> NSDate {
+    let date = containedIn["$date"] as? Double
+    let timestamp = NSTimeInterval(date! / 1000)
+    return NSDate(timeIntervalSince1970: timestamp)
+}


### PR DESCRIPTION
Related to the issue #36.

The data structure (e.g. `{"$date": 1461882019000}`) dictates the use of a suitable number primitive.

Double has length of 64-bit, so should be enough like forever.