### PR TITLE
Using UTF8 instead of ascii when JSON encoding

### DIFF
--- a/SwiftDDP/DDPExtensions.swift
+++ b/SwiftDDP/DDPExtensions.swift
@@ -52,7 +52,7 @@ extension String {
 extension NSDictionary {
     func stringValue() -> String? {
         if let data = try? NSJSONSerialization.dataWithJSONObject(self, options: NSJSONWritingOptions(rawValue: 0)) {
-            return NSString(data: data, encoding: NSASCIIStringEncoding) as? String
+            return String(data: data, encoding: NSUTF8StringEncoding)
         }
         return nil
     }


### PR DESCRIPTION
Hey. 
Shouldn't we use UTF-8 instead of ASCII when encoding messages? 
This fixed issues I had with special characters.