### PR TITLE
Upgraded to Swift 3

### DIFF
--- a/SwiftDDP.podspec
+++ b/SwiftDDP.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
   s.platform = :ios, '8.1'
   s.source_files = 'SwiftDDP/**/*.swift'
 
-  s.dependency 'CryptoSwift', '~> 0.3'
-  s.dependency 'SwiftWebSocket', '~> 2.6.0'
+  s.dependency 'CryptoSwift', '~> 0.6.6'
+  s.dependency 'SwiftWebSocket', '~> 2.6.5'
   s.dependency 'XCGLogger'
 
 end

--- a/SwiftDDP.xcodeproj/project.pbxproj
+++ b/SwiftDDP.xcodeproj/project.pbxproj
@@ -408,9 +408,11 @@
 					};
 					D02A71DB1BBEFBCA00940C17 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0810;
 					};
 					D02A72521BBF07AF00940C17 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0810;
 					};
 				};
 			};
@@ -776,6 +778,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.houndfish.SwiftDDP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -797,6 +800,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.houndfish.SwiftDDP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -812,6 +816,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.houndfish.SwiftDDPTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -827,6 +832,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.houndfish.SwiftDDPTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/SwiftDDP/AbstractCollection.swift
+++ b/SwiftDDP/AbstractCollection.swift
@@ -20,10 +20,10 @@
 
 import Foundation
 
-public class AbstractCollection: NSObject, MeteorCollectionType {
+open class AbstractCollection: NSObject, MeteorCollectionType {
     
-    public var name:String
-    public let client = Meteor.client
+    open var name:String
+    open let client = Meteor.client
     
     public init(name:String) {
         self.name = name
@@ -43,7 +43,7 @@ public class AbstractCollection: NSObject, MeteorCollectionType {
     - parameter fields:         an optional NSDictionary with the documents properties
     */
     
-    public func documentWasAdded(collection:String, id:String, fields:NSDictionary?) {}
+    open func documentWasAdded(_ collection:String, id:String, fields:NSDictionary?) {}
     
     /**
     Invoked when a document has been changed on the server.
@@ -54,7 +54,7 @@ public class AbstractCollection: NSObject, MeteorCollectionType {
     - parameter cleared:                    Optional array of strings (field names to delete)
     */
     
-    public func documentWasChanged(collection:String, id:String, fields:NSDictionary?, cleared:[String]?) {}
+    open func documentWasChanged(_ collection:String, id:String, fields:NSDictionary?, cleared:[String]?) {}
     
     /**
     Invoked when a document has been removed on the server.
@@ -63,6 +63,6 @@ public class AbstractCollection: NSObject, MeteorCollectionType {
     - parameter id:             the string unique id that identifies the document on the server
     */
     
-    public func documentWasRemoved(collection:String, id:String) {}
+    open func documentWasRemoved(_ collection:String, id:String) {}
     
 }

--- a/SwiftDDP/DDPClient.swift
+++ b/SwiftDDP/DDPClient.swift
@@ -355,7 +355,7 @@ open class DDPClient: NSObject {
      - parameter callback:   The closure to be executed when the method has been executed
      */
     
-    open func method(_ name: String, params: Any?, callback: DDPMethodCallback?) -> String {
+    @discardableResult open func method(_ name: String, params: Any?, callback: DDPMethodCallback?) -> String {
         let id = getId()
         let message = ["msg":"method", "method":name, "id":id] as NSMutableDictionary
         if let p = params { message["params"] = p }
@@ -375,7 +375,7 @@ open class DDPClient: NSObject {
     // Subscribe
     //
     
-    internal func sub(_ id: String, name: String, params: [Any]?, callback: DDPCallback?) -> String {
+    @discardableResult internal func sub(_ id: String, name: String, params: [Any]?, callback: DDPCallback?) -> String {
         
         if let completionCallback = callback {
             let completion = Completion(callback: completionCallback)
@@ -398,7 +398,7 @@ open class DDPClient: NSObject {
      - parameter params:     An object containing method arguments, if any
      */
     
-    open func sub(_ name: String, params: [Any]?) -> String {
+    @discardableResult open func sub(_ name: String, params: [Any]?) -> String {
         let id = getId()
         return sub(id, name: name, params: params, callback:nil)
     }

--- a/SwiftDDP/DDPClient.swift
+++ b/SwiftDDP/DDPClient.swift
@@ -32,7 +32,7 @@ import XCGLogger
 
 let log = XCGLogger(identifier: "DDP")
 
-public typealias DDPMethodCallback = (_ result:AnyObject?, _ error:DDPError?) -> ()
+public typealias DDPMethodCallback = (_ result:Any?, _ error:DDPError?) -> ()
 public typealias DDPConnectedCallback = (_ session:String) -> ()
 public typealias DDPCallback = () -> ()
 
@@ -269,7 +269,7 @@ open class DDPClient: NSObject {
             if let id = message.id,                              // Message has id
                 let completion = self.resultCallbacks[id],          // There is a callback registered for the message
                 let result = message.result {
-                    completion.execute(result as AnyObject?, error: message.error)
+                    completion.execute(result, error: message.error)
                     self.resultCallbacks[id] = nil
             } else if let id = message.id,
                 let completion = self.resultCallbacks[id] {
@@ -355,7 +355,7 @@ open class DDPClient: NSObject {
      - parameter callback:   The closure to be executed when the method has been executed
      */
     
-    open func method(_ name: String, params: AnyObject?, callback: DDPMethodCallback?) -> String {
+    open func method(_ name: String, params: Any?, callback: DDPMethodCallback?) -> String {
         let id = getId()
         let message = ["msg":"method", "method":name, "id":id] as NSMutableDictionary
         if let p = params { message["params"] = p }
@@ -375,7 +375,7 @@ open class DDPClient: NSObject {
     // Subscribe
     //
     
-    internal func sub(_ id: String, name: String, params: [AnyObject]?, callback: DDPCallback?) -> String {
+    internal func sub(_ id: String, name: String, params: [Any]?, callback: DDPCallback?) -> String {
         
         if let completionCallback = callback {
             let completion = Completion(callback: completionCallback)
@@ -398,7 +398,7 @@ open class DDPClient: NSObject {
      - parameter params:     An object containing method arguments, if any
      */
     
-    open func sub(_ name: String, params: [AnyObject]?) -> String {
+    open func sub(_ name: String, params: [Any]?) -> String {
         let id = getId()
         return sub(id, name: name, params: params, callback:nil)
     }
@@ -413,7 +413,7 @@ open class DDPClient: NSObject {
      - parameter callback:   The closure to be executed when the server sends a 'ready' message
      */
     
-    open func sub(_ name:String, params: [AnyObject]?, callback: DDPCallback?) -> String {
+    open func sub(_ name:String, params: [Any]?, callback: DDPCallback?) -> String {
         let id = getId()
         print("Subscribing to ID \(id)")
         return sub(id, name: name, params: params, callback: callback)

--- a/SwiftDDP/DDPClient.swift
+++ b/SwiftDDP/DDPClient.swift
@@ -32,8 +32,8 @@ import XCGLogger
 
 let log = XCGLogger(identifier: "DDP")
 
-public typealias DDPMethodCallback = (result:AnyObject?, error:DDPError?) -> ()
-public typealias DDPConnectedCallback = (session:String) -> ()
+public typealias DDPMethodCallback = (_ result:AnyObject?, _ error:DDPError?) -> ()
+public typealias DDPConnectedCallback = (_ session:String) -> ()
 public typealias DDPCallback = () -> ()
 
 
@@ -42,85 +42,85 @@ public typealias DDPCallback = () -> ()
  */
 
 public protocol SwiftDDPDelegate {
-    func ddpUserDidLogin(user:String)
-    func ddpUserDidLogout(user:String)
+    func ddpUserDidLogin(_ user:String)
+    func ddpUserDidLogout(_ user:String)
 }
 
 /**
  DDPClient is the base class for communicating with a server using the DDP protocol
  */
 
-public class DDPClient: NSObject {
+open class DDPClient: NSObject {
     
     // included for storing login id and token
-    internal let userData = NSUserDefaults.standardUserDefaults()
+    internal let userData = UserDefaults.standard
     
-    let background: NSOperationQueue = {
-        let queue = NSOperationQueue()
+    let background: OperationQueue = {
+        let queue = OperationQueue()
         queue.name = "DDP Background Data Queue"
-        queue.qualityOfService = .Background
+        queue.qualityOfService = .background
         return queue
     }()
     
     // Callbacks execute in the order they're received
-    internal let callbackQueue: NSOperationQueue = {
-        let queue = NSOperationQueue()
+    internal let callbackQueue: OperationQueue = {
+        let queue = OperationQueue()
         queue.name = "DDP Callback Queue"
         queue.maxConcurrentOperationCount = 1
-        queue.qualityOfService = .UserInitiated
+        queue.qualityOfService = .userInitiated
         return queue
     }()
     
     // Document messages are processed in the order that they are received,
     // separately from callbacks
-    internal let documentQueue: NSOperationQueue = {
-        let queue = NSOperationQueue()
+    internal let documentQueue: OperationQueue = {
+        let queue = OperationQueue()
         queue.name = "DDP Background Queue"
         queue.maxConcurrentOperationCount = 1
-        queue.qualityOfService = .Background
+        queue.qualityOfService = .background
         return queue
     }()
     
     // Hearbeats get a special queue so that they're not blocked by
     // other operations, causing the connection to close
-    internal let heartbeat: NSOperationQueue = {
-        let queue = NSOperationQueue()
+    internal let heartbeat: OperationQueue = {
+        let queue = OperationQueue()
         queue.name = "DDP Heartbeat Queue"
-        queue.qualityOfService = .Utility
+        queue.qualityOfService = .utility
         return queue
     }()
     
-    let userBackground: NSOperationQueue = {
-        let queue = NSOperationQueue()
+    let userBackground: OperationQueue = {
+        let queue = OperationQueue()
         queue.name = "DDP High Priority Background Queue"
-        queue.qualityOfService = .UserInitiated
+        queue.qualityOfService = .userInitiated
         return queue
     }()
     
-    let userMainQueue: NSOperationQueue = {
-        let queue = NSOperationQueue.mainQueue()
+    let userMainQueue: OperationQueue = {
+        let queue = OperationQueue.main
         queue.name = "DDP High Priorty Main Queue"
-        queue.qualityOfService = .UserInitiated
+        queue.qualityOfService = .userInitiated
         return queue
     }()
     
-    private var socket:WebSocket!{
+    fileprivate var socket:WebSocket!{
         didSet{ socket.allowSelfSignedSSL = self.allowSelfSignedSSL }
     }
 
-    private var server:(ping:NSDate?, pong:NSDate?) = (nil, nil)
+    fileprivate var server:(ping:Date?, pong:Date?) = (nil, nil)
     
     internal var resultCallbacks:[String:Completion] = [:]
     internal var subCallbacks:[String:Completion] = [:]
     internal var unsubCallbacks:[String:Completion] = [:]
     
-    public var url:String!
-    private var subscriptions = [String:(id:String, name:String, ready:Bool)]()
+    open var url:String!
+    fileprivate var subscriptions = [String:(id:String, name:String, ready:Bool)]()
     
     internal var events = DDPEvents()
     internal var connection:(ddp:Bool, session:String?) = (false, nil)
     
-    public var delegate:SwiftDDPDelegate?
+    open var delegate:SwiftDDPDelegate?
     
 
     // MARK: Settings
@@ -129,7 +129,7 @@ public class DDPClient: NSObject {
     Boolean value that determines whether the
     */
     
-    public var allowSelfSignedSSL:Bool = false {
+    open var allowSelfSignedSSL:Bool = false {
         didSet{
             guard let currentSocket = socket else { return }
             currentSocket.allowSelfSignedSSL = allowSelfSignedSSL
@@ -141,9 +141,9 @@ public class DDPClient: NSObject {
     Possible values: .Verbose, .Debug, .Info, .Warning, .Error, .Severe, .None
     */
     
-    public var logLevel = XCGLogger.LogLevel.None {
+    open var logLevel = XCGLogger.Level.none {
         didSet {
-            log.setup(logLevel, showLogIdentifier: true, showFunctionName: true, showThreadName: true, showLogLevel: true, showFileNames: false, showLineNumbers: true, showDate: false, writeToFile: nil, fileLogLevel: .None)
+            log.setup(level: logLevel, showLogIdentifier: true, showFunctionName: true, showThreadName: true, showLevel: true, showFileNames: false, showLineNumbers: true, showDate: false, writeToFile: nil, fileLevel: .none)
         }
     }
     
@@ -155,13 +155,13 @@ public class DDPClient: NSObject {
     Creates a random String id
     */
     
-    public func getId() -> String {
+    open func getId() -> String {
         let numbers = Set<Character>(["0","1","2","3","4","5","6","7","8","9"])
-        let uuid = NSUUID().UUIDString.stringByReplacingOccurrencesOfString("-", withString: "")
+        let uuid = UUID().uuidString.replacingOccurrences(of: "-", with: "")
         var id = ""
         for character in uuid.characters {
             if (!numbers.contains(character) && (round(Float(arc4random()) / Float(UINT32_MAX)) == 1)) {
-                id += String(character).lowercaseString
+                id += String(character).lowercased()
             } else {
                 id += String(character)
             }
@@ -176,10 +176,10 @@ public class DDPClient: NSObject {
      - parameter callback:   A closure that takes a String argument with the value of the websocket session token
      */
     
-    public func connect(url:String, callback:DDPConnectedCallback?) {
+    open func connect(_ url:String, callback:DDPConnectedCallback?) {
         self.url = url
         // capture the thread context in which the function is called
-        let executionQueue = NSOperationQueue.currentQueue()
+        let executionQueue = OperationQueue.current
         
         socket = WebSocket(url)
         //Create backoff
@@ -199,7 +199,7 @@ public class DDPClient: NSObject {
         socket.event.error = events.onWebsocketError
         
         socket.event.open = {
-            self.heartbeat.addOperationWithBlock() {
+            self.heartbeat.addOperation() {
                 
                 // Add a subscription to loginServices to each connection event
                 let callbackWithServiceConfiguration = { (session:String) in
@@ -216,7 +216,7 @@ public class DDPClient: NSObject {
                             self.sub(subscription.1.id, name: subscription.1.name, params: nil, callback: nil)
                         }
                     })
-                    callback?(session: session)
+                    callback?(session)
                 }
                 
                 var completion = Completion(callback: callbackWithServiceConfiguration)
@@ -229,7 +229,7 @@ public class DDPClient: NSObject {
         }
         
         socket.event.message = { message in
-            self.background.addOperationWithBlock() {
+            self.background.addOperation() {
                 if let text = message as? String {
                     do { try self.ddpMessageHandler(DDPMessage(message: text)) }
                     catch { log.debug("Message handling error. Raw message: \(text)")}
@@ -238,24 +238,24 @@ public class DDPClient: NSObject {
         }
     }
     
-    private func ping() {
-        heartbeat.addOperationWithBlock() {
+    fileprivate func ping() {
+        heartbeat.addOperation() {
             self.sendMessage(["msg":"ping", "id":self.getId()])
         }
     }
     
     // Respond to a server ping
-    private func pong(ping: DDPMessage) {
-        heartbeat.addOperationWithBlock() {
-            self.server.ping = NSDate()
+    fileprivate func pong(_ ping: DDPMessage) {
+        heartbeat.addOperation() {
+            self.server.ping = Date()
             var response = ["msg":"pong"]
             if let id = ping.id { response["id"] = id }
-            self.sendMessage(response)
+            self.sendMessage(response as NSDictionary)
         }
     }
     
     // Parse DDP messages and dispatch to the appropriate function
-    internal func ddpMessageHandler(message: DDPMessage) throws {
+    internal func ddpMessageHandler(_ message: DDPMessage) throws {
         
         log.debug("Received message: \(message.json)")
         
@@ -265,11 +265,11 @@ public class DDPClient: NSObject {
             self.connection = (true, message.session!)
             self.events.onConnected.execute(message.session!)
             
-        case .Result: callbackQueue.addOperationWithBlock() {
+        case .Result: callbackQueue.addOperation() {
             if let id = message.id,                              // Message has id
                 let completion = self.resultCallbacks[id],          // There is a callback registered for the message
                 let result = message.result {
-                    completion.execute(result, error: message.error)
+                    completion.execute(result as AnyObject?, error: message.error)
                     self.resultCallbacks[id] = nil
             } else if let id = message.id,
                 let completion = self.resultCallbacks[id] {
@@ -280,7 +280,7 @@ public class DDPClient: NSObject {
             
             // Principal callbacks for managing data
             // Document was added
-        case .Added: documentQueue.addOperationWithBlock() {
+        case .Added: documentQueue.addOperation() {
             if let collection = message.collection,
                 let id = message.id {
                     self.documentWasAdded(collection, id: id, fields: message.fields)
@@ -288,7 +288,7 @@ public class DDPClient: NSObject {
             }
             
             // Document was changed
-        case .Changed: documentQueue.addOperationWithBlock() {
+        case .Changed: documentQueue.addOperation() {
             if let collection = message.collection,
                 let id = message.id {
                     self.documentWasChanged(collection, id: id, fields: message.fields, cleared: message.cleared)
@@ -296,7 +296,7 @@ public class DDPClient: NSObject {
             }
             
             // Document was removed
-        case .Removed: documentQueue.addOperationWithBlock() {
+        case .Removed: documentQueue.addOperation() {
             if let collection = message.collection,
                 let id = message.id {
                     self.documentWasRemoved(collection, id: id)
@@ -304,14 +304,14 @@ public class DDPClient: NSObject {
             }
             
             // Notifies you when the result of a method changes
-        case .Updated: documentQueue.addOperationWithBlock() {
+        case .Updated: documentQueue.addOperation() {
             if let methods = message.methods {
                 self.methodWasUpdated(methods)
             }
             }
             
             // Callbacks for managing subscriptions
-        case .Ready: documentQueue.addOperationWithBlock() {
+        case .Ready: documentQueue.addOperation() {
             if let subs = message.subs {
                 self.ready(subs)
             }
@@ -319,17 +319,17 @@ public class DDPClient: NSObject {
             
             // Callback that fires when subscription has been completely removed
             //
-        case .Nosub: documentQueue.addOperationWithBlock() {
+        case .Nosub: documentQueue.addOperation() {
             if let id = message.id {
                 self.nosub(id, error: message.error)
             }
             }
             
-        case .Ping: heartbeat.addOperationWithBlock() { self.pong(message) }
+        case .Ping: heartbeat.addOperation() { self.pong(message) }
             
-        case .Pong: heartbeat.addOperationWithBlock() { self.server.pong = NSDate() }
+        case .Pong: heartbeat.addOperation() { self.server.pong = Date() }
             
-        case .Error: background.addOperationWithBlock() {
+        case .Error: background.addOperation() {
             self.didReceiveErrorMessage(DDPError(json: message.json))
             }
             
@@ -338,7 +338,7 @@ public class DDPClient: NSObject {
         }
     }
     
-    private func sendMessage(message:NSDictionary) {
+    fileprivate func sendMessage(_ message:NSDictionary) {
         if let m = message.stringValue() {
             self.socket.send(m)
         }
@@ -355,7 +355,7 @@ public class DDPClient: NSObject {
      - parameter callback:   The closure to be executed when the method has been executed
      */
     
-    public func method(name: String, params: AnyObject?, callback: DDPMethodCallback?) -> String {
+    open func method(_ name: String, params: AnyObject?, callback: DDPMethodCallback?) -> String {
         let id = getId()
         let message = ["msg":"method", "method":name, "id":id] as NSMutableDictionary
         if let p = params { message["params"] = p }
@@ -365,7 +365,7 @@ public class DDPClient: NSObject {
             self.resultCallbacks[id] = completion
         }
         
-        userBackground.addOperationWithBlock() {
+        userBackground.addOperation() {
             self.sendMessage(message)
         }
         return id
@@ -375,7 +375,7 @@ public class DDPClient: NSObject {
     // Subscribe
     //
     
-    internal func sub(id: String, name: String, params: [AnyObject]?, callback: DDPCallback?) -> String {
+    internal func sub(_ id: String, name: String, params: [AnyObject]?, callback: DDPCallback?) -> String {
         
         if let completionCallback = callback {
             let completion = Completion(callback: completionCallback)
@@ -385,7 +385,7 @@ public class DDPClient: NSObject {
         self.subscriptions[id] = (id, name, false)
         let message = ["msg":"sub", "name":name, "id":id] as NSMutableDictionary
         if let p = params { message["params"] = p }
-        userBackground.addOperationWithBlock() {
+        userBackground.addOperation() {
             self.sendMessage(message)
         }
         return id
@@ -398,7 +398,7 @@ public class DDPClient: NSObject {
      - parameter params:     An object containing method arguments, if any
      */
     
-    public func sub(name: String, params: [AnyObject]?) -> String {
+    open func sub(_ name: String, params: [AnyObject]?) -> String {
         let id = getId()
         return sub(id, name: name, params: params, callback:nil)
     }
@@ -413,14 +413,14 @@ public class DDPClient: NSObject {
      - parameter callback:   The closure to be executed when the server sends a 'ready' message
      */
     
-    public func sub(name:String, params: [AnyObject]?, callback: DDPCallback?) -> String {
+    open func sub(_ name:String, params: [AnyObject]?, callback: DDPCallback?) -> String {
         let id = getId()
         print("Subscribing to ID \(id)")
         return sub(id, name: name, params: params, callback: callback)
     }
     
     // Iterates over the Dictionary of subscriptions to find a subscription by name
-    internal func findSubscription(name:String) -> [String] {
+    internal func findSubscription(_ name:String) -> [String] {
         var subs:[String] = []
         for sub in  subscriptions.values {
             if sub.name == name {
@@ -428,6 +428,16 @@ public class DDPClient: NSObject {
             }
         }
         return subs
+    }
+    
+    // Iterates over the Dictionary of subscriptions to find a subscription by name
+    internal func subscriptionReady(_ name:String) -> Bool {
+        for sub in  subscriptions.values {
+            if sub.name == name {
+                return sub.ready
+            }
+        }
+        return false
     }
     
     //
@@ -440,9 +450,9 @@ public class DDPClient: NSObject {
      - parameter callback:   The closure to be executed when the server sends a 'ready' message
      */
     
-    public func unsub(withName name: String) -> [String] {
+    open func unsub(withName name: String) -> [String] {
         return findSubscription(name).map({id in
-            background.addOperationWithBlock() { self.sendMessage(["msg":"unsub", "id": id]) }
+            background.addOperation() { self.sendMessage(["msg":"unsub", "id": id]) }
             unsub(withId: id, callback: nil)
             return id
         })
@@ -457,19 +467,19 @@ public class DDPClient: NSObject {
      - parameter callback:   The closure to be executed when the server sends a 'ready' message
      */
     
-    public func unsub(withId id: String, callback: DDPCallback?) {
+    open func unsub(withId id: String, callback: DDPCallback?) {
         if let completionCallback = callback {
             let completion = Completion(callback: completionCallback)
             unsubCallbacks[id] = completion
         }
-        background.addOperationWithBlock() { self.sendMessage(["msg":"unsub", "id":id]) }
+        background.addOperation() { self.sendMessage(["msg":"unsub", "id":id]) }
     }
     
     //
     // Responding to server subscription messages
     //
     
-    private func ready(subs: [String]) {
+    fileprivate func ready(_ subs: [String]) {
         for id in subs {
             if let completion = subCallbacks[id] {
                 completion.execute()                // Run the callback
@@ -484,8 +494,8 @@ public class DDPClient: NSObject {
         }
     }
     
-    private func nosub(id: String, error: DDPError?) {
-        if let e = error where (e.isValid == true) {
+    fileprivate func nosub(_ id: String, error: DDPError?) {
+        if let e = error, (e.isValid == true) {
             log.error("\(e)")
         } else {
             if let completion = unsubCallbacks[id],
@@ -513,7 +523,7 @@ public class DDPClient: NSObject {
     - parameter subscriptionName:           The name of the subscription
     */
     
-    public func subscriptionIsReady(subscriptionId: String, subscriptionName:String) {}
+    open func subscriptionIsReady(_ subscriptionId: String, subscriptionName:String) {}
     
     /**
      Executes when a subscription is removed.
@@ -522,7 +532,7 @@ public class DDPClient: NSObject {
      - parameter subscriptionName:           The name of the subscription
      */
     
-    public func subscriptionWasRemoved(subscriptionId:String, subscriptionName:String) {}
+    open func subscriptionWasRemoved(_ subscriptionId:String, subscriptionName:String) {}
     
     
     /**
@@ -533,8 +543,8 @@ public class DDPClient: NSObject {
      - parameter fields:                     The documents properties
      */
     
-    public func documentWasAdded(collection:String, id:String, fields:NSDictionary?) {
-        if let added = events.onAdded { added(collection: collection, id: id, fields: fields) }
+    open func documentWasAdded(_ collection:String, id:String, fields:NSDictionary?) {
+        if let added = events.onAdded { added(collection, id, fields) }
     }
     
     /**
@@ -544,8 +554,8 @@ public class DDPClient: NSObject {
      - parameter id:                         The document's unique id
      */
     
-    public func documentWasRemoved(collection:String, id:String) {
-        if let removed = events.onRemoved { removed(collection: collection, id: id) }
+    open func documentWasRemoved(_ collection:String, id:String) {
+        if let removed = events.onRemoved { removed(collection, id) }
     }
     
     /**
@@ -557,8 +567,8 @@ public class DDPClient: NSObject {
      - parameter cleared:                    Optional array of strings (field names to delete)
      */
     
-    public func documentWasChanged(collection:String, id:String, fields:NSDictionary?, cleared:[String]?) {
-        if let changed = events.onChanged { changed(collection:collection, id:id, fields:fields, cleared:cleared) }
+    open func documentWasChanged(_ collection:String, id:String, fields:NSDictionary?, cleared:[String]?) {
+        if let changed = events.onChanged { changed(collection, id, fields, cleared as NSArray?) }
     }
     
     /**
@@ -567,8 +577,8 @@ public class DDPClient: NSObject {
      - parameter methods:                    An array of strings (ids passed to 'method', all of whose writes have been reflected in data messages)
      */
     
-    public func methodWasUpdated(methods:[String]) {
-        if let updated = events.onUpdated { updated(methods: methods) }
+    open func methodWasUpdated(_ methods:[String]) {
+        if let updated = events.onUpdated { updated(methods) }
     }
     
     /**
@@ -577,7 +587,7 @@ public class DDPClient: NSObject {
      - parameter message:                    A DDPError object with information about the error
      */
     
-    public func didReceiveErrorMessage(message: DDPError) {
-        if let error = events.onError { error(message: message) }
+    open func didReceiveErrorMessage(_ message: DDPError) {
+        if let error = events.onError { error(message) }
     }
 }

--- a/SwiftDDP/DDPCompletion.swift
+++ b/SwiftDDP/DDPCompletion.swift
@@ -28,48 +28,48 @@ not available, execution defaults to the main queue.
 
 public struct Completion {
     
-    var executionQueue:NSOperationQueue? = NSOperationQueue.currentQueue()
+    var executionQueue:OperationQueue? = OperationQueue.current
     var methodCallback:DDPMethodCallback?
     var connectedCallback:DDPConnectedCallback?
     var callback:DDPCallback?
     
-    init(callback:DDPMethodCallback) {
+    init(callback:@escaping DDPMethodCallback) {
         methodCallback = callback
     }
     
-    init(callback:DDPConnectedCallback) {
+    init(callback:@escaping DDPConnectedCallback) {
         connectedCallback = callback
     }
     
-    init(callback:DDPCallback) {
+    init(callback:@escaping DDPCallback) {
         self.callback = callback
     }
     
-    func execute(result:AnyObject?, error:DDPError?) {
+    func execute(_ result:AnyObject?, error:DDPError?) {
         
         if let callback = methodCallback {
             if let queue = executionQueue {
-                queue.addOperationWithBlock() {
-                    callback(result: result, error: error)
+                queue.addOperation() {
+                    callback(result, error)
                 }
             } else {
-                NSOperationQueue.mainQueue().addOperationWithBlock() {
-                    callback(result: result, error: error)
+                OperationQueue.main.addOperation() {
+                    callback(result, error)
                 }
             }
         }
     }
     
-    func execute(session:String) {
+    func execute(_ session:String) {
         
         if let callback = connectedCallback {
             if let queue = executionQueue {
-                queue.addOperationWithBlock() {
-                    callback(session: session)
+                queue.addOperation() {
+                    callback(session)
                 }
             } else {
-                NSOperationQueue.mainQueue().addOperationWithBlock() {
-                    callback(session: session)
+                OperationQueue.main.addOperation() {
+                    callback(session)
                 }
             }
         }
@@ -79,11 +79,11 @@ public struct Completion {
         
         if let callback = self.callback {
             if let queue = executionQueue {
-                queue.addOperationWithBlock() {
+                queue.addOperation() {
                     callback()
                 }
             } else {
-                NSOperationQueue.mainQueue().addOperationWithBlock() {
+                OperationQueue.main.addOperation() {
                     callback()
                 }
             }

--- a/SwiftDDP/DDPCompletion.swift
+++ b/SwiftDDP/DDPCompletion.swift
@@ -45,7 +45,7 @@ public struct Completion {
         self.callback = callback
     }
     
-    func execute(_ result:AnyObject?, error:DDPError?) {
+    func execute(_ result:Any?, error:DDPError?) {
         
         if let callback = methodCallback {
             if let queue = executionQueue {

--- a/SwiftDDP/DDPEvents.swift
+++ b/SwiftDDP/DDPEvents.swift
@@ -36,7 +36,7 @@ public struct DDPEvents {
     - parameter clean:      A boolean value indicating if the websocket connection was closed cleanly
     */
     
-    internal var onWebsocketClose:    ((code:Int, reason:String, clean:Bool) -> ())?
+    internal var onWebsocketClose:    ((_ code:Int, _ reason:String, _ clean:Bool) -> ())?
     
     /**
     onWebsocketError executes when the websocket connection returns an error.
@@ -44,7 +44,7 @@ public struct DDPEvents {
     - parameter error:      An ErrorType object describing the error
     */
     
-    internal var onWebsocketError:    (error:ErrorType) -> () = {error in log.error("websocket error \(error)")}
+    internal var onWebsocketError:    (_ error:Error) -> () = {error in log.error("websocket error \(error)")}
     
     /**
     onConnected executes when the client makes a DDP connection
@@ -76,7 +76,7 @@ public struct DDPEvents {
     - parameter fields:         an optional NSDictionary with the documents properties
     */
     
-    public var onAdded:             ((collection:String, id:String, fields:NSDictionary?) -> ())?
+    public var onAdded:             ((_ collection:String, _ id:String, _ fields:NSDictionary?) -> ())?
     
     /**
     onChanged executes when the server sends an instruction to modify a local document
@@ -88,7 +88,7 @@ public struct DDPEvents {
     - parameter cleared:        an optional array of string property names to delete
     */
     
-    public var onChanged:           ((collection:String, id:String, fields:NSDictionary?, cleared:NSArray?) -> ())?
+    public var onChanged:           ((_ collection:String, _ id:String, _ fields:NSDictionary?, _ cleared:NSArray?) -> ())?
     
     /**
     onRemoved executes when the server sends an instruction to remove a document from the local collection
@@ -97,7 +97,7 @@ public struct DDPEvents {
     - parameter id:             the string unique id that identifies the document on the server
     */
     
-    public var onRemoved:           ((collection:String, id:String) -> ())?
+    public var onRemoved:           ((_ collection:String, _ id:String) -> ())?
     
     // RPC Messages
     // public var onResult:            (json: NSDictionary?, callback:(result:AnyObject?, error:AnyObject?) -> ()) -> () = {json, callback in callback(result: json, error:nil) }
@@ -109,7 +109,7 @@ public struct DDPEvents {
     - parameter methods:    An array of method id strings
     */
     
-    public var onUpdated:           ((methods: [String]) -> ())?
+    public var onUpdated:           ((_ methods: [String]) -> ())?
     
     /**
     onError executes when the client receives a DDP error message
@@ -117,7 +117,7 @@ public struct DDPEvents {
     - parameter message:    A DDPError message describing the error
     */
     
-    public var onError:             ((message:DDPError) -> ())?
+    public var onError:             ((_ message:DDPError) -> ())?
     
 }
 

--- a/SwiftDDP/DDPEvents.swift
+++ b/SwiftDDP/DDPEvents.swift
@@ -100,7 +100,7 @@ public struct DDPEvents {
     public var onRemoved:           ((_ collection:String, _ id:String) -> ())?
     
     // RPC Messages
-    // public var onResult:            (json: NSDictionary?, callback:(result:AnyObject?, error:AnyObject?) -> ()) -> () = {json, callback in callback(result: json, error:nil) }
+    // public var onResult:            (json: NSDictionary?, callback:(result:Any?, error:Any?) -> ()) -> () = {json, callback in callback(result: json, error:nil) }
     
     /**
     onUpdated executes when the server sends a notification that all the consequences of a method call have

--- a/SwiftDDP/DDPExponentialBackoff.swift
+++ b/SwiftDDP/DDPExponentialBackoff.swift
@@ -38,16 +38,16 @@ class DDPExponentialBackoff {
     }
     
     //Cached original interval time
-    private var _reconnectionRetryInterval:Double!
+    fileprivate var _reconnectionRetryInterval:Double = 0
     
     
-    private var reconnectionRetryInterval:Double!
-    private var maxWaitInterval:Double!
-    private var multiplier:Double!
+    fileprivate var reconnectionRetryInterval:Double
+    fileprivate var maxWaitInterval:Double
+    fileprivate var multiplier:Double
     
     
     ///Perform a closure with increasing exponential delay time up to a max wait interval
-    func createBackoff(closure:()->()) {
+    func createBackoff(_ closure:@escaping ()->()) {
         
         let previousRetryInterval = self.reconnectionRetryInterval
         let newRetryInterval = min(previousRetryInterval * multiplier,maxWaitInterval)
@@ -55,12 +55,8 @@ class DDPExponentialBackoff {
         self.reconnectionRetryInterval = previousRetryInterval < maxWaitInterval ? newRetryInterval: maxWaitInterval
         
         
-        dispatch_after(
-            dispatch_time(
-                DISPATCH_TIME_NOW,
-                Int64(self.reconnectionRetryInterval * Double(NSEC_PER_SEC))
-            ),
-            dispatch_get_main_queue(), closure)
+        DispatchQueue.main.asyncAfter(
+            deadline: DispatchTime.now() + Double(Int64(self.reconnectionRetryInterval * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: closure)
 //        print(reconnectionRetryInterval)
     }
     
@@ -70,7 +66,7 @@ class DDPExponentialBackoff {
     }
     
     //Sets the backoff
-    func setBackoff(retryInterval:Double,maxWaitInterval:Double,multiplier:Double){
+    func setBackoff(_ retryInterval:Double,maxWaitInterval:Double,multiplier:Double){
         self.reconnectionRetryInterval = retryInterval
         self._reconnectionRetryInterval = retryInterval
         self.maxWaitInterval = maxWaitInterval

--- a/SwiftDDP/DDPExtensions.swift
+++ b/SwiftDDP/DDPExtensions.swift
@@ -79,7 +79,7 @@ extension DDPClient {
     - parameter params:     An object containing method arguments, if any
     */
     
-    public func subscribe(_ name:String, params:[AnyObject]) -> String { return sub(name, params:params) }
+    public func subscribe(_ name:String, params:[Any]) -> String { return sub(name, params:params) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -91,7 +91,7 @@ extension DDPClient {
     - parameter callback:   The closure to be executed when the server sends a 'ready' message
     */
     
-    public func subscribe(_ name:String, params:[AnyObject]?, callback: DDPCallback?) -> String { return sub(name, params:params, callback:callback) }
+    public func subscribe(_ name:String, params:[Any]?, callback: DDPCallback?) -> String { return sub(name, params:params, callback:callback) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -251,7 +251,7 @@ extension DDPClient {
     }
     
     // Callback runs on main thread
-    public func login(_ params: NSDictionary, callback: ((_ result: AnyObject?, _ error: DDPError?) -> ())?) {
+    public func login(_ params: NSDictionary, callback: ((_ result: Any?, _ error: DDPError?) -> ())?) {
         
         // method is run on the userBackground queue
         method("login", params: NSArray(arrayLiteral: params)) { result, error in
@@ -347,7 +347,7 @@ extension DDPClient {
     }
     
     
-    public func signup(_ params:NSDictionary, callback:((_ result: AnyObject?, _ error: DDPError?) -> ())?) {
+    public func signup(_ params:NSDictionary, callback:((_ result: Any?, _ error: DDPError?) -> ())?) {
         method("createUser", params: NSArray(arrayLiteral: params)) { result, error in
             guard let e = error, (e.isValid == true) else {
                 
@@ -383,7 +383,7 @@ extension DDPClient {
     
     */
     
-    public func signupWithEmail(_ email: String, password: String, callback: ((_ result:AnyObject?, _ error:DDPError?) -> ())?) {
+    public func signupWithEmail(_ email: String, password: String, callback: ((_ result:Any?, _ error:DDPError?) -> ())?) {
         let params = ["email":email, "password":["digest":password.sha256(), "algorithm":"sha-256"]] as [String : Any]
         signup(params as NSDictionary, callback: callback)
     }
@@ -392,7 +392,7 @@ extension DDPClient {
     Invokes a Meteor method to create a user account with a given email and password, and a NSDictionary containing a user profile
     */
     
-    public func signupWithEmail(_ email: String, password: String, profile: NSDictionary, callback: ((_ result:AnyObject?, _ error:DDPError?) -> ())?) {
+    public func signupWithEmail(_ email: String, password: String, profile: NSDictionary, callback: ((_ result:Any?, _ error:DDPError?) -> ())?) {
         let params = ["email":email, "password":["digest":password.sha256(), "algorithm":"sha-256"], "profile":profile] as [String : Any]
         signup(params as NSDictionary, callback: callback)
     }
@@ -401,7 +401,7 @@ extension DDPClient {
      Invokes a Meteor method to create a user account with a given username, email and password, and a NSDictionary containing a user profile
      */
     
-    public func signupWithUsername(_ username: String, password: String, email: String?, profile: NSDictionary?, callback: ((_ result:AnyObject?, _ error:DDPError?) -> ())?) {
+    public func signupWithUsername(_ username: String, password: String, email: String?, profile: NSDictionary?, callback: ((_ result:Any?, _ error:DDPError?) -> ())?) {
         let params: NSMutableDictionary = ["username":username, "password":["digest":password.sha256(), "algorithm":"sha-256"]]
         if let email = email {
             params.setValue(email, forKey: "email")

--- a/SwiftDDP/DDPExtensions.swift
+++ b/SwiftDDP/DDPExtensions.swift
@@ -31,18 +31,18 @@ private let DDP_LOGGED_IN = "DDP_LOGGED_IN"
 public let DDP_USER_DID_LOGIN = "DDP_USER_DID_LOGIN"
 public let DDP_USER_DID_LOGOUT = "DDP_USER_DID_LOGOUT"
 
-let SWIFT_DDP_CALLBACK_DISPATCH_TIME = DISPATCH_TIME_FOREVER
+let SWIFT_DDP_CALLBACK_DISPATCH_TIME = DispatchTime.distantFuture
 
 private let syncWarning = {(name:String) -> Void in
-    if NSThread.isMainThread() {
+    if Thread.isMainThread {
         print("\(name) is running synchronously on the main thread. This will block the main thread and should be run on a background thread")
     }
 }
 
 extension String {
     func dictionaryValue() -> NSDictionary? {
-        if let data = self.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) {
-            let dictionary = try? NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(rawValue: 0)) as! NSDictionary
+        if let data = self.data(using: String.Encoding.utf8, allowLossyConversion: false) {
+            let dictionary = try? JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions(rawValue: 0)) as! NSDictionary
             return dictionary
         }
         return nil
@@ -51,8 +51,8 @@ extension String {
 
 extension NSDictionary {
     func stringValue() -> String? {
-        if let data = try? NSJSONSerialization.dataWithJSONObject(self, options: NSJSONWritingOptions(rawValue: 0)) {
-            return String(data: data, encoding: NSUTF8StringEncoding)
+        if let data = try? JSONSerialization.data(withJSONObject: self, options: JSONSerialization.WritingOptions(rawValue: 0)) {
+            return String(data: data, encoding: String.Encoding.utf8)
         }
         return nil
     }
@@ -70,7 +70,7 @@ extension DDPClient {
     - parameter name:       The name of the subscription
     */
     
-    public func subscribe(name:String) -> String { return sub(name, params:nil) }
+    public func subscribe(_ name:String) -> String { return sub(name, params:nil) }
     
     /**
     Sends a subscription request to the server.
@@ -79,7 +79,7 @@ extension DDPClient {
     - parameter params:     An object containing method arguments, if any
     */
     
-    public func subscribe(name:String, params:[AnyObject]) -> String { return sub(name, params:params) }
+    public func subscribe(_ name:String, params:[AnyObject]) -> String { return sub(name, params:params) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -91,7 +91,7 @@ extension DDPClient {
     - parameter callback:   The closure to be executed when the server sends a 'ready' message
     */
     
-    public func subscribe(name:String, params:[AnyObject]?, callback: DDPCallback?) -> String { return sub(name, params:params, callback:callback) }
+    public func subscribe(_ name:String, params:[AnyObject]?, callback: DDPCallback?) -> String { return sub(name, params:params, callback:callback) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -102,7 +102,7 @@ extension DDPClient {
     - parameter callback:   The closure to be executed when the server sends a 'ready' message
     */
     
-    public func subscribe(name:String, callback: DDPCallback?) -> String { return sub(name, params:nil, callback:callback) }
+    public func subscribe(_ name:String, callback: DDPCallback?) -> String { return sub(name, params:nil, callback:callback) }
     
     
     /**
@@ -113,7 +113,7 @@ extension DDPClient {
     - parameter callback:   A closure with result and error arguments describing the result of the operation
     */
     
-    public func insert(collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
+    public func insert(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
         let arg = "/\(collection)/insert"
         return self.method(arg, params: document, callback: callback)
     }
@@ -125,7 +125,7 @@ extension DDPClient {
     - parameter document:   An NSArray of documents to insert
     */
     
-    public func insert(collection: String, document: NSArray) -> String {
+    public func insert(_ collection: String, document: NSArray) -> String {
         return insert(collection, document: document, callback:nil)
     }
     
@@ -140,16 +140,16 @@ extension DDPClient {
         
         syncWarning("Insert")
         
-        let semaphore = dispatch_semaphore_create(0)
+        let semaphore = DispatchSemaphore(value: 0)
         var serverResponse = Result()
         
         insert(collection, document:document) { result, error in
             serverResponse.result = result
             serverResponse.error = error
-            dispatch_semaphore_signal(semaphore)
+            semaphore.signal()
         }
         
-        dispatch_semaphore_wait(semaphore, SWIFT_DDP_CALLBACK_DISPATCH_TIME)
+        semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
         
         return serverResponse
     }
@@ -162,7 +162,7 @@ extension DDPClient {
     - parameter callback:   A closure with result and error arguments describing the result of the operation
     */
     
-    public func update(collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
+    public func update(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
         let arg = "/\(collection)/update"
         return method(arg, params: document, callback: callback)
     }
@@ -174,7 +174,7 @@ extension DDPClient {
     - parameter document:   An NSArray of documents to update
     */
     
-    public func update(collection: String, document: NSArray) -> String {
+    public func update(_ collection: String, document: NSArray) -> String {
         return update(collection, document: document, callback:nil)
     }
     
@@ -188,16 +188,16 @@ extension DDPClient {
     public func update(sync collection: String, document: NSArray) -> Result {
         syncWarning("Update")
         
-        let semaphore = dispatch_semaphore_create(0)
+        let semaphore = DispatchSemaphore(value: 0)
         var serverResponse = Result()
         
         update(collection, document:document) { result, error in
             serverResponse.result = result
             serverResponse.error = error
-            dispatch_semaphore_signal(semaphore)
+            semaphore.signal()
         }
         
-        dispatch_semaphore_wait(semaphore, SWIFT_DDP_CALLBACK_DISPATCH_TIME)
+        semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
         
         return serverResponse
     }
@@ -210,7 +210,7 @@ extension DDPClient {
     - parameter callback:   A closure with result and error arguments describing the result of the operation
     */
     
-    public func remove(collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
+    public func remove(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
         let arg = "/\(collection)/remove"
         return method(arg, params: document, callback: callback)
     }
@@ -222,7 +222,7 @@ extension DDPClient {
     - parameter document:   An NSArray of documents to remove
     */
     
-    public func remove(collection: String, document: NSArray) -> String  {
+    public func remove(_ collection: String, document: NSArray) -> String  {
         return remove(collection, document: document, callback:nil)
     }
     
@@ -236,33 +236,33 @@ extension DDPClient {
     public func remove(sync collection: String, document: NSArray) -> Result {
         syncWarning("Remove")
         
-        let semaphore = dispatch_semaphore_create(0)
+        let semaphore = DispatchSemaphore(value: 0)
         var serverResponse = Result()
         
         remove(collection, document:document) { result, error in
             serverResponse.result = result
             serverResponse.error = error
-            dispatch_semaphore_signal(semaphore)
+            semaphore.signal()
         }
         
-        dispatch_semaphore_wait(semaphore, SWIFT_DDP_CALLBACK_DISPATCH_TIME)
+        semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
         
         return serverResponse
     }
     
     // Callback runs on main thread
-    public func login(params: NSDictionary, callback: ((result: AnyObject?, error: DDPError?) -> ())?) {
+    public func login(_ params: NSDictionary, callback: ((_ result: AnyObject?, _ error: DDPError?) -> ())?) {
         
         // method is run on the userBackground queue
         method("login", params: NSArray(arrayLiteral: params)) { result, error in
-            guard let e = error where (e.isValid == true) else {
+            guard let e = error, (e.isValid == true) else {
                 
-                if let user = params["user"] {
+                if let user = params["user"] as? NSDictionary {
                     if let email = user["email"] {
-                        self.userData.setObject(email, forKey: DDP_EMAIL)
+                        self.userData.set(email, forKey: DDP_EMAIL)
                     }
                     if let username = user["username"] {
-                        self.userData.setObject(username, forKey: DDP_USERNAME)
+                        self.userData.set(username, forKey: DDP_USERNAME)
                     }
                 }
                 
@@ -271,17 +271,17 @@ extension DDPClient {
                     let token = data["token"] as? String,
                     let tokenExpires = data["tokenExpires"] as? NSDictionary {
                         let expiration = dateFromTimestamp(tokenExpires)
-                        self.userData.setObject(id, forKey: DDP_ID)
-                        self.userData.setObject(token, forKey: DDP_TOKEN)
-                        self.userData.setObject(expiration, forKey: DDP_TOKEN_EXPIRES)
+                        self.userData.set(id, forKey: DDP_ID)
+                        self.userData.set(token, forKey: DDP_TOKEN)
+                        self.userData.set(expiration, forKey: DDP_TOKEN_EXPIRES)
                 }
                 
-                self.userMainQueue.addOperationWithBlock() {
+                self.userMainQueue.addOperation() {
                     
-                    if let c = callback { c(result:result, error:error) }
-                    self.userData.setObject(true, forKey: DDP_LOGGED_IN)
+                    if let c = callback { c(result, error) }
+                    self.userData.set(true, forKey: DDP_LOGGED_IN)
                     
-                    NSNotificationCenter.defaultCenter().postNotificationName(DDP_USER_DID_LOGIN, object: nil)
+                    NotificationCenter.default.post(name: Notification.Name(rawValue: DDP_USER_DID_LOGIN), object: nil)
 
                     if let _ = self.delegate {
                         self.delegate!.ddpUserDidLogin(self.user()!)
@@ -293,7 +293,7 @@ extension DDPClient {
             }
             
             log.debug("Login error: \(e)")
-            if let c = callback { c(result: result, error: error) }
+            if let c = callback { c(result, error) }
         }
     }
 
@@ -305,7 +305,7 @@ extension DDPClient {
     - parameter callback:   A closure with result and error parameters describing the outcome of the operation
     */
     
-    public func loginWithPassword(email: String, password: String, callback: DDPMethodCallback?) {
+    public func loginWithPassword(_ email: String, password: String, callback: DDPMethodCallback?) {
         if !(loginWithToken(callback)) {
             let params = ["user": ["email": email], "password":["digest": password.sha256(), "algorithm":"sha-256"]] as NSDictionary
             login(params, callback: callback)
@@ -320,7 +320,7 @@ extension DDPClient {
      - parameter callback:   A closure with result and error parameters describing the outcome of the operation
      */
     
-    public func loginWithUsername(username: String, password: String, callback: DDPMethodCallback?) {
+    public func loginWithUsername(_ username: String, password: String, callback: DDPMethodCallback?) {
         if !(loginWithToken(callback)) {
             let params = ["user": ["username": username], "password":["digest": password.sha256(), "algorithm":"sha-256"]] as NSDictionary
             login(params, callback: callback)
@@ -333,11 +333,11 @@ extension DDPClient {
     - parameter callback:   A closure with result and error parameters describing the outcome of the operation
     */
     
-    public func loginWithToken(callback: DDPMethodCallback?) -> Bool {
-        if let token = userData.stringForKey(DDP_TOKEN),
-            let tokenDate = userData.objectForKey(DDP_TOKEN_EXPIRES) {
+    public func loginWithToken(_ callback: DDPMethodCallback?) -> Bool {
+        if let token = userData.string(forKey: DDP_TOKEN),
+            let tokenDate = userData.object(forKey: DDP_TOKEN_EXPIRES) as? Date {
                 print("Found token & token expires \(token), \(tokenDate)")
-                if (tokenDate.compare(NSDate()) == NSComparisonResult.OrderedDescending) {
+                if (tokenDate.compare(Date()) == ComparisonResult.orderedDescending) {
                     let params = ["resume":token] as NSDictionary
                     login(params, callback:callback)
                     return true
@@ -347,16 +347,16 @@ extension DDPClient {
     }
     
     
-    public func signup(params:NSDictionary, callback:((result: AnyObject?, error: DDPError?) -> ())?) {
+    public func signup(_ params:NSDictionary, callback:((_ result: AnyObject?, _ error: DDPError?) -> ())?) {
         method("createUser", params: NSArray(arrayLiteral: params)) { result, error in
-            guard let e = error where (e.isValid == true) else {
+            guard let e = error, (e.isValid == true) else {
                 
                 if let email = params["email"] {
-                    self.userData.setObject(email, forKey: DDP_EMAIL)
+                    self.userData.set(email, forKey: DDP_EMAIL)
                 }
                 
                 if let username = params["username"] {
-                    self.userData.setObject(username, forKey: DDP_USERNAME)
+                    self.userData.set(username, forKey: DDP_USERNAME)
                 }
                 
                 if let data = result as? NSDictionary,
@@ -364,18 +364,18 @@ extension DDPClient {
                     let token = data["token"] as? String,
                     let tokenExpires = data["tokenExpires"] as? NSDictionary {
                         let expiration = dateFromTimestamp(tokenExpires)
-                        self.userData.setObject(id, forKey: DDP_ID)
-                        self.userData.setObject(token, forKey: DDP_TOKEN)
-                        self.userData.setObject(expiration, forKey: DDP_TOKEN_EXPIRES)
+                        self.userData.set(id, forKey: DDP_ID)
+                        self.userData.set(token, forKey: DDP_TOKEN)
+                        self.userData.set(expiration, forKey: DDP_TOKEN_EXPIRES)
                         self.userData.synchronize()
                 }
-                if let c = callback { c(result:result, error:error) }
-                self.userData.setObject(true, forKey: DDP_LOGGED_IN)
+                if let c = callback { c(result, error) }
+                self.userData.set(true, forKey: DDP_LOGGED_IN)
                 return
             }
             
             log.debug("login error: \(e)")
-            if let c = callback { c(result: result, error: error) }
+            if let c = callback { c(result, error) }
         }
     }
     /**
@@ -383,25 +383,25 @@ extension DDPClient {
     
     */
     
-    public func signupWithEmail(email: String, password: String, callback: ((result:AnyObject?, error:DDPError?) -> ())?) {
-        let params = ["email":email, "password":["digest":password.sha256(), "algorithm":"sha-256"]]
-        signup(params, callback: callback)
+    public func signupWithEmail(_ email: String, password: String, callback: ((_ result:AnyObject?, _ error:DDPError?) -> ())?) {
+        let params = ["email":email, "password":["digest":password.sha256(), "algorithm":"sha-256"]] as [String : Any]
+        signup(params as NSDictionary, callback: callback)
     }
     
     /**
     Invokes a Meteor method to create a user account with a given email and password, and a NSDictionary containing a user profile
     */
     
-    public func signupWithEmail(email: String, password: String, profile: NSDictionary, callback: ((result:AnyObject?, error:DDPError?) -> ())?) {
-        let params = ["email":email, "password":["digest":password.sha256(), "algorithm":"sha-256"], "profile":profile]
-        signup(params, callback: callback)
+    public func signupWithEmail(_ email: String, password: String, profile: NSDictionary, callback: ((_ result:AnyObject?, _ error:DDPError?) -> ())?) {
+        let params = ["email":email, "password":["digest":password.sha256(), "algorithm":"sha-256"], "profile":profile] as [String : Any]
+        signup(params as NSDictionary, callback: callback)
     }
     
     /**
      Invokes a Meteor method to create a user account with a given username, email and password, and a NSDictionary containing a user profile
      */
     
-    public func signupWithUsername(username: String, password: String, email: String?, profile: NSDictionary?, callback: ((result:AnyObject?, error:DDPError?) -> ())?) {
+    public func signupWithUsername(_ username: String, password: String, email: String?, profile: NSDictionary?, callback: ((_ result:AnyObject?, _ error:DDPError?) -> ())?) {
         let params: NSMutableDictionary = ["username":username, "password":["digest":password.sha256(), "algorithm":"sha-256"]]
         if let email = email {
             params.setValue(email, forKey: "email")
@@ -417,7 +417,7 @@ extension DDPClient {
     */
     
     public func userId() -> String? {
-        return self.userData.objectForKey(DDP_ID) as? String
+        return self.userData.object(forKey: DDP_ID) as? String
     }
     
     /**
@@ -425,9 +425,9 @@ extension DDPClient {
     */
     
     public func user() -> String? {
-        if let username = self.userData.objectForKey(DDP_USERNAME) as? String {
+        if let username = self.userData.object(forKey: DDP_USERNAME) as? String {
             return username
-        } else if let email = self.userData.objectForKey(DDP_EMAIL) as? String {
+        } else if let email = self.userData.object(forKey: DDP_EMAIL) as? String {
             return email
         }
         return nil
@@ -435,12 +435,12 @@ extension DDPClient {
     
     
     internal func resetUserData() {
-        self.userData.setObject(false, forKey: DDP_LOGGED_IN)
-        self.userData.removeObjectForKey(DDP_ID)
-        self.userData.removeObjectForKey(DDP_EMAIL)
-        self.userData.removeObjectForKey(DDP_USERNAME)
-        self.userData.removeObjectForKey(DDP_TOKEN)
-        self.userData.removeObjectForKey(DDP_TOKEN_EXPIRES)
+        self.userData.set(false, forKey: DDP_LOGGED_IN)
+        self.userData.removeObject(forKey: DDP_ID)
+        self.userData.removeObject(forKey: DDP_EMAIL)
+        self.userData.removeObject(forKey: DDP_USERNAME)
+        self.userData.removeObject(forKey: DDP_TOKEN)
+        self.userData.removeObject(forKey: DDP_TOKEN_EXPIRES)
         self.userData.synchronize()
     }
     
@@ -459,23 +459,23 @@ extension DDPClient {
     - parameter callback:   A closure with result and error parameters describing the outcome of the operation
     */
     
-    public func logout(callback:DDPMethodCallback?) {
+    public func logout(_ callback:DDPMethodCallback?) {
         method("logout", params: nil) { result, error in
                 if (error == nil) {
-                    self.userMainQueue.addOperationWithBlock() {
+                    self.userMainQueue.addOperation() {
                         let user = self.user()!
                         if let _ = self.delegate {
                             self.delegate!.ddpUserDidLogout(user)
                         }
                         self.resetUserData()
-                        NSNotificationCenter.defaultCenter().postNotificationName(DDP_USER_DID_LOGOUT, object: nil)
+                        NotificationCenter.default.post(name: Notification.Name(rawValue: DDP_USER_DID_LOGOUT), object: nil)
                     }
                     
                 } else {
                     log.error("\(error)")
                 }
                 
-                if let c = callback { c(result: result, error: error) }
+                if let c = callback { c(result, error) }
             }
         }
     
@@ -485,7 +485,7 @@ extension DDPClient {
     - parameter url:        The server url
     */
     
-    public func resume(url:String, callback:DDPCallback?) {
+    public func resume(_ url:String, callback:DDPCallback?) {
         connect(url) { session in
             if let _ = self.user() {
                 self.loginWithToken() { result, error in
@@ -524,7 +524,7 @@ extension DDPClient {
     */
     
     public func loggedIn() -> Bool {
-        if let userLoggedIn = self.userData.objectForKey(DDP_LOGGED_IN) as? Bool where (userLoggedIn == true) {
+        if let userLoggedIn = self.userData.object(forKey: DDP_LOGGED_IN) as? Bool, (userLoggedIn == true) {
             return true
         }
         return false

--- a/SwiftDDP/DDPExtensions.swift
+++ b/SwiftDDP/DDPExtensions.swift
@@ -113,7 +113,7 @@ extension DDPClient {
     - parameter callback:   A closure with result and error arguments describing the result of the operation
     */
     
-    public func insert(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
+    @discardableResult public func insert(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
         let arg = "/\(collection)/insert"
         return self.method(arg, params: document, callback: callback)
     }
@@ -149,7 +149,7 @@ extension DDPClient {
             semaphore.signal()
         }
         
-        semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
+        _ = semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
         
         return serverResponse
     }
@@ -162,7 +162,7 @@ extension DDPClient {
     - parameter callback:   A closure with result and error arguments describing the result of the operation
     */
     
-    public func update(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
+    @discardableResult public func update(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
         let arg = "/\(collection)/update"
         return method(arg, params: document, callback: callback)
     }
@@ -197,7 +197,7 @@ extension DDPClient {
             semaphore.signal()
         }
         
-        semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
+        _ = semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
         
         return serverResponse
     }
@@ -210,7 +210,7 @@ extension DDPClient {
     - parameter callback:   A closure with result and error arguments describing the result of the operation
     */
     
-    public func remove(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
+    @discardableResult public func remove(_ collection: String, document: NSArray, callback: DDPMethodCallback?) -> String {
         let arg = "/\(collection)/remove"
         return method(arg, params: document, callback: callback)
     }
@@ -245,7 +245,7 @@ extension DDPClient {
             semaphore.signal()
         }
         
-        semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
+        _ = semaphore.wait(timeout: SWIFT_DDP_CALLBACK_DISPATCH_TIME)
         
         return serverResponse
     }
@@ -333,7 +333,7 @@ extension DDPClient {
     - parameter callback:   A closure with result and error parameters describing the outcome of the operation
     */
     
-    public func loginWithToken(_ callback: DDPMethodCallback?) -> Bool {
+    @discardableResult public func loginWithToken(_ callback: DDPMethodCallback?) -> Bool {
         if let token = userData.string(forKey: DDP_TOKEN),
             let tokenDate = userData.object(forKey: DDP_TOKEN_EXPIRES) as? Date {
                 print("Found token & token expires \(token), \(tokenDate)")

--- a/SwiftDDP/DDPMessage.swift
+++ b/SwiftDDP/DDPMessage.swift
@@ -101,9 +101,9 @@ public struct DDPMessage {
     Converts an NSDictionary to a JSON string
     */
     
-    public static func toString(json:AnyObject) -> String? {
-        if let data = try? NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue: 0)) {
-            let message = NSString(data: data, encoding: NSASCIIStringEncoding) as String?
+    public static func toString(_ json:AnyObject) -> String? {
+        if let data = try? JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions(rawValue: 0)) {
+            let message = NSString(data: data, encoding: String.Encoding.ascii.rawValue) as String?
             return message
         }
         return nil
@@ -140,8 +140,8 @@ public struct DDPMessage {
         return json.allKeys as! [String]
     }
     
-    public func hasProperty(name:String) -> Bool {
-        if let property = json[name] where ((property as! NSObject) != NSNull()) {
+    public func hasProperty(_ name:String) -> Bool {
+        if let property = json[name], ((property as! NSObject) != NSNull()) {
             return true
         }
         return false
@@ -255,8 +255,8 @@ public struct DDPMessage {
     The optional result object, containing the result of a method call
     */
     
-    public var result:AnyObject? {
-        get { return json["result"] }
+    public var result:Any? {
+        get { return json.object(forKey: "result") as Any? }
     }
     
     /**
@@ -297,9 +297,9 @@ public struct DDPMessage {
 A struct encapsulating a DDP error message
 */
 
-public struct DDPError: ErrorType {
+public struct DDPError: Error {
     
-    private var json:NSDictionary?
+    fileprivate var json:NSDictionary?
     
     /**
     The string error code

--- a/SwiftDDP/DDPMessage.swift
+++ b/SwiftDDP/DDPMessage.swift
@@ -101,7 +101,7 @@ public struct DDPMessage {
     Converts an NSDictionary to a JSON string
     */
     
-    public static func toString(_ json:AnyObject) -> String? {
+    public static func toString(_ json:Any) -> String? {
         if let data = try? JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions(rawValue: 0)) {
             let message = NSString(data: data, encoding: String.Encoding.ascii.rawValue) as String?
             return message
@@ -335,7 +335,7 @@ public struct DDPError: Error {
         return false
     }
     
-    init(json:AnyObject?) {
+    init(json:Any?) {
         self.json = json as? NSDictionary
     }
 }

--- a/SwiftDDP/DDPMethodResult.swift
+++ b/SwiftDDP/DDPMethodResult.swift
@@ -30,7 +30,7 @@ public struct Result {
     The result of the method call
     */
     
-    public var result:AnyObject?
+    public var result:Any?
     
     /**
     An error object describing the server-side error, or nil if the method completed successfully

--- a/SwiftDDP/DDPUtilities.swift
+++ b/SwiftDDP/DDPUtilities.swift
@@ -22,14 +22,14 @@ import Foundation
 
 // Base64
 
-func randomBase64String(n: Int = 20) -> String {
+func randomBase64String(_ n: Int = 20) -> String {
     
     var string = ""
     let BASE64_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
     
     for _ in 1...n {
         let r = arc4random() % UInt32(BASE64_CHARS.characters.count)
-        let index = BASE64_CHARS.startIndex.advancedBy(Int(r))
+        let index = BASE64_CHARS.characters.index(BASE64_CHARS.startIndex, offsetBy: Int(r))
         let c = BASE64_CHARS[index]
         string += String(c)
     }
@@ -37,15 +37,15 @@ func randomBase64String(n: Int = 20) -> String {
     return string
 }
 
-func toBase64(string: String) -> String {
-    let encodedData = (string as NSString).dataUsingEncoding(NSUTF8StringEncoding)
-    let base64String = encodedData!.base64EncodedStringWithOptions(NSDataBase64EncodingOptions(rawValue: 0))
+func toBase64(_ string: String) -> String {
+    let encodedData = (string as NSString).data(using: String.Encoding.utf8.rawValue)
+    let base64String = encodedData!.base64EncodedString(options: NSData.Base64EncodingOptions(rawValue: 0))
     return base64String as String
 }
 
-func fromBase64(string: String) -> String {
-    let decodedData = NSData(base64EncodedString: string, options: NSDataBase64DecodingOptions(rawValue: 0))
-    let decodedString = NSString(data: decodedData!, encoding: NSUTF8StringEncoding)
+func fromBase64(_ string: String) -> String {
+    let decodedData = Data(base64Encoded: string, options: NSData.Base64DecodingOptions(rawValue: 0))
+    let decodedString = NSString(data: decodedData!, encoding: String.Encoding.utf8.rawValue)
     return decodedString as! String
 }
 
@@ -55,7 +55,7 @@ func fromBase64(string: String) -> String {
 // Returns a dictionary of arguments
 func getArguments(fromUrl url: String) -> [String:String] {
     var componentsDictionary:[String:String] = [:]
-    let components = NSURLComponents(string: url)
+    let components = URLComponents(string: url)
     components?.queryItems?.forEach { item in componentsDictionary[item.name] = item.value }
     return componentsDictionary
 }
@@ -68,8 +68,8 @@ func getValue(fromUrl url: String, forArgument argument:String) -> String? {
 
 // Misc
 
-func dateFromTimestamp(containedIn: NSDictionary) -> NSDate {
+func dateFromTimestamp(_ containedIn: NSDictionary) -> Date {
     let date = containedIn["$date"] as? Double
-    let timestamp = NSTimeInterval(date! / 1000)
-    return NSDate(timeIntervalSince1970: timestamp)
+    let timestamp = TimeInterval(date! / 1000)
+    return Date(timeIntervalSince1970: timestamp)
 }

--- a/SwiftDDP/EJSON.swift
+++ b/SwiftDDP/EJSON.swift
@@ -25,13 +25,13 @@ import Foundation
 // {"$escape": THING}                   // Escaped things that might otherwise look like EJSON types
 // {"$type": TYPENAME, "$value": VALUE} // User specified types
 
-public class EJSON: NSObject {
+open class EJSON: NSObject {
     
     /**
     Determines whether a given key is an eJSON key
     */
     
-    public static func isEJSON(key:String) -> Bool {
+    open static func isEJSON(_ key:String) -> Bool {
         switch key {
         case "$date": return true
         case "$binary": return true
@@ -44,12 +44,12 @@ public class EJSON: NSObject {
     Converts an eJSON date to NSDate
     */
     
-    public static func convertToNSDate(ejson:NSDictionary) -> NSDate {
-        let timeInterval = NSTimeInterval(ejson.valueForKey("$date") as! Double) / 1000
-        return NSDate(timeIntervalSince1970: timeInterval)
+    open static func convertToNSDate(_ ejson:NSDictionary) -> Date {
+        let timeInterval = TimeInterval(ejson.value(forKey: "$date") as! Double) / 1000
+        return Date(timeIntervalSince1970: timeInterval)
     }
     
-    public static func convertToEJSONDate(date:NSDate) -> [String:Double] {
+    open static func convertToEJSONDate(_ date:Date) -> [String:Double] {
         let timeInterval = Double(date.timeIntervalSince1970) * 1000
         print("Date -> \(date), \(timeInterval)")
         return ["$date": timeInterval]

--- a/SwiftDDP/Meteor.swift
+++ b/SwiftDDP/Meteor.swift
@@ -67,7 +67,7 @@ open class Meteor {
     - parameter name:       The name of the subscription.
     */
     
-    open static func subscribe(_ name:String) -> String { return client.sub(name, params:nil) }
+    @discardableResult open static func subscribe(_ name:String) -> String { return client.sub(name, params:nil) }
     
     
     /**
@@ -77,7 +77,7 @@ open class Meteor {
     - parameter params:     An object containing method arguments, if any.
     */
     
-    open static func subscribe(_ name:String, params:[Any]) -> String { return client.sub(name, params:params) }
+    @discardableResult open static func subscribe(_ name:String, params:[Any]) -> String { return client.sub(name, params:params) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -89,7 +89,7 @@ open class Meteor {
     - parameter callback:   The closure to be executed when the server sends a 'ready' message.
     */
     
-    open static func subscribe(_ name:String, params:[Any]?, callback: DDPCallback?) -> String { return client.sub(name, params:params, callback:callback) }
+    @discardableResult open static func subscribe(_ name:String, params:[Any]?, callback: DDPCallback?) -> String { return client.sub(name, params:params, callback:callback) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -100,7 +100,7 @@ open class Meteor {
     - parameter callback:   The closure to be executed when the server sends a 'ready' message.
     */
     
-    open static func subscribe(_ name:String, callback: DDPCallback?) -> String { return client.sub(name, params: nil, callback: callback) }
+    @discardableResult open static func subscribe(_ name:String, callback: DDPCallback?) -> String { return client.sub(name, params: nil, callback: callback) }
     
     /**
     Sends an unsubscribe request to the server. Unsubscibes to all subscriptions with the provided name.
@@ -108,14 +108,14 @@ open class Meteor {
      
     */
     
-    open static func unsubscribe(_ name:String) -> [String] { return client.unsub(withName: name) }
+    @discardableResult open static func unsubscribe(_ name:String) -> [String] { return client.unsub(withName: name) }
     
     /**
      Sends an unsubscribe request to the server using a subscription id. This allows fine-grained control of subscriptions. For example, you can unsubscribe to specific combinations of subscriptions and subscription parameters. 
      - parameter id: An id string returned from a subscription request
      */
     
-    open static func unsubscribe(withId id:String) { return client.unsub(withId: id, callback: nil) }
+    @discardableResult open static func unsubscribe(withId id:String) { return client.unsub(withId: id, callback: nil) }
     
     /**
      Sends an unsubscribe request to the server using a subscription id. This allows fine-grained control of subscriptions. For example, you can unsubscribe to specific combinations of subscriptions and subscription parameters. If a callback is passed, the callback asynchronously
@@ -124,7 +124,7 @@ open class Meteor {
      - parameter callback:   The closure to be executed when the method has been executed
      */
     
-    open static func unsubscribe(withId id:String, callback:DDPCallback?) { return client.unsub(withId: id, callback: callback) }
+    @discardableResult open static func unsubscribe(withId id:String, callback:DDPCallback?) { return client.unsub(withId: id, callback: callback) }
     
     /**
     Calls a method on the server. If a callback is passed, the callback is asynchronously
@@ -137,7 +137,7 @@ open class Meteor {
     - parameter callback:   The closure to be executed when the method has been executed
     */
     
-    open static func call(_ name:String, params:[Any]?, callback:DDPMethodCallback?) -> String? {
+    @discardableResult open static func call(_ name:String, params:[Any]?, callback:DDPMethodCallback?) -> String? {
         return client.method(name, params: params, callback: callback)
     }
     

--- a/SwiftDDP/Meteor.swift
+++ b/SwiftDDP/Meteor.swift
@@ -34,22 +34,22 @@ enum Error: String {
 */
 
 public protocol MeteorCollectionType {
-    func documentWasAdded(collection:String, id:String, fields:NSDictionary?)
-    func documentWasChanged(collection:String, id:String, fields:NSDictionary?, cleared:[String]?)
-    func documentWasRemoved(collection:String, id:String)
+    func documentWasAdded(_ collection:String, id:String, fields:NSDictionary?)
+    func documentWasChanged(_ collection:String, id:String, fields:NSDictionary?, cleared:[String]?)
+    func documentWasRemoved(_ collection:String, id:String)
 }
 
 /**
 Meteor is a class to simplify communicating with and consuming MeteorJS server services
 */
 
-public class Meteor {
+open class Meteor {
     
     /**
     client is a singleton instance of DDPClient
     */
         
-    public static let client = Meteor.Client()          // Client is a singleton object
+    open static let client = Meteor.Client()          // Client is a singleton object
     
     internal static var collections = [String:MeteorCollectionType]()
     
@@ -57,7 +57,7 @@ public class Meteor {
     returns a Meteor collection, if it exists
     */
     
-    public static func collection(name:String) -> MeteorCollectionType? {
+    open static func collection(_ name:String) -> MeteorCollectionType? {
         return collections[name]
     }
     
@@ -67,7 +67,7 @@ public class Meteor {
     - parameter name:       The name of the subscription.
     */
     
-    public static func subscribe(name:String) -> String { return client.sub(name, params:nil) }
+    open static func subscribe(_ name:String) -> String { return client.sub(name, params:nil) }
     
     
     /**
@@ -77,7 +77,7 @@ public class Meteor {
     - parameter params:     An object containing method arguments, if any.
     */
     
-    public static func subscribe(name:String, params:[AnyObject]) -> String { return client.sub(name, params:params) }
+    open static func subscribe(_ name:String, params:[AnyObject]) -> String { return client.sub(name, params:params) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -89,7 +89,7 @@ public class Meteor {
     - parameter callback:   The closure to be executed when the server sends a 'ready' message.
     */
     
-    public static func subscribe(name:String, params:[AnyObject]?, callback: DDPCallback?) -> String { return client.sub(name, params:params, callback:callback) }
+    open static func subscribe(_ name:String, params:[AnyObject]?, callback: DDPCallback?) -> String { return client.sub(name, params:params, callback:callback) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -100,7 +100,7 @@ public class Meteor {
     - parameter callback:   The closure to be executed when the server sends a 'ready' message.
     */
     
-    public static func subscribe(name:String, callback: DDPCallback?) -> String { return client.sub(name, params: nil, callback: callback) }
+    open static func subscribe(_ name:String, callback: DDPCallback?) -> String { return client.sub(name, params: nil, callback: callback) }
     
     /**
     Sends an unsubscribe request to the server. Unsubscibes to all subscriptions with the provided name.
@@ -108,14 +108,14 @@ public class Meteor {
      
     */
     
-    public static func unsubscribe(name:String) -> [String] { return client.unsub(withName: name) }
+    open static func unsubscribe(_ name:String) -> [String] { return client.unsub(withName: name) }
     
     /**
      Sends an unsubscribe request to the server using a subscription id. This allows fine-grained control of subscriptions. For example, you can unsubscribe to specific combinations of subscriptions and subscription parameters. 
      - parameter id: An id string returned from a subscription request
      */
     
-    public static func unsubscribe(withId id:String) { return client.unsub(withId: id, callback: nil) }
+    open static func unsubscribe(withId id:String) { return client.unsub(withId: id, callback: nil) }
     
     /**
      Sends an unsubscribe request to the server using a subscription id. This allows fine-grained control of subscriptions. For example, you can unsubscribe to specific combinations of subscriptions and subscription parameters. If a callback is passed, the callback asynchronously
@@ -124,7 +124,7 @@ public class Meteor {
      - parameter callback:   The closure to be executed when the method has been executed
      */
     
-    public static func unsubscribe(withId id:String, callback:DDPCallback?) { return client.unsub(withId: id, callback: callback) }
+    open static func unsubscribe(withId id:String, callback:DDPCallback?) { return client.unsub(withId: id, callback: callback) }
     
     /**
     Calls a method on the server. If a callback is passed, the callback is asynchronously
@@ -137,8 +137,8 @@ public class Meteor {
     - parameter callback:   The closure to be executed when the method has been executed
     */
     
-    public static func call(name:String, params:[AnyObject]?, callback:DDPMethodCallback?) -> String? {
-        return client.method(name, params: params, callback: callback)
+    open static func call(_ name:String, params:[AnyObject]?, callback:DDPMethodCallback?) -> String? {
+        return client.method(name, params: params as AnyObject?, callback: callback)
     }
     
     /**
@@ -149,7 +149,7 @@ public class Meteor {
     - parameter password:   A string password 
     */
     
-    public static func connect(url:String, email:String, password:String) {
+    open static func connect(_ url:String, email:String, password:String) {
         client.connect(url) { session in
             client.loginWithPassword(email, password: password) { result, error in
                 guard let _ = error else {
@@ -168,7 +168,7 @@ public class Meteor {
     - parameter url:        The url of a Meteor server
     */
     
-    public static func connect(url:String) {
+    open static func connect(_ url:String) {
         client.resume(url, callback: nil)
     }
     
@@ -179,7 +179,7 @@ public class Meteor {
     - parameter callback:   An optional closure to be executed after the connection is established
     */
     
-    public static func connect(url:String, callback:DDPCallback?) {
+    open static func connect(_ url:String, callback:DDPCallback?) {
         client.resume(url, callback: callback)
     }
 
@@ -193,7 +193,7 @@ public class Meteor {
     
     */
     
-    public static func signupWithEmail(email: String, password: String, callback: DDPMethodCallback?) {
+    open static func signupWithEmail(_ email: String, password: String, callback: DDPMethodCallback?) {
         client.signupWithEmail(email, password: password, callback: callback)
     }
     
@@ -207,7 +207,7 @@ public class Meteor {
      
      */
     
-    public static func signupWithEmail(email: String, password: String, profile: NSDictionary, callback: DDPMethodCallback?) {
+    open static func signupWithEmail(_ email: String, password: String, profile: NSDictionary, callback: DDPMethodCallback?) {
         client.signupWithEmail(email, password: password, profile: profile, callback: callback)
     }
     
@@ -222,7 +222,7 @@ public class Meteor {
      
      */
     
-    public static func signupWithUsername(username: String, password: String, email: String? = nil, profile: NSDictionary? = nil, callback: DDPMethodCallback? = nil) {
+    open static func signupWithUsername(_ username: String, password: String, email: String? = nil, profile: NSDictionary? = nil, callback: DDPMethodCallback? = nil) {
         client.signupWithUsername(username, password: password, email: email, profile: profile, callback: callback)
     }
     
@@ -234,7 +234,7 @@ public class Meteor {
     - parameter callback:   A closure with result and error parameters describing the outcome of the operation
     */
     
-    public static func loginWithPassword(email:String, password:String, callback:DDPMethodCallback?) {
+    open static func loginWithPassword(_ email:String, password:String, callback:DDPMethodCallback?) {
         client.loginWithPassword(email, password: password, callback: callback)
     }
     
@@ -245,7 +245,7 @@ public class Meteor {
     - parameter password:   A password string
     */
     
-    public static func loginWithPassword(email:String, password:String) {
+    open static func loginWithPassword(_ email:String, password:String) {
         client.loginWithPassword(email, password: password, callback: nil)
     }
     
@@ -257,11 +257,11 @@ public class Meteor {
      - parameter callback:   A closure with result and error parameters describing the outcome of the operation
      */
     
-    public static func loginWithUsername(username:String, password:String, callback:DDPMethodCallback? = nil) {
+    open static func loginWithUsername(_ username:String, password:String, callback:DDPMethodCallback? = nil) {
         client.loginWithUsername(username, password: password, callback: callback)
     }
     
-    internal static func loginWithService<T: UIViewController>(service: String, clientId: String, viewController: T) {
+    internal static func loginWithService<T: UIViewController>(_ service: String, clientId: String, viewController: T) {
         
         // Resume rather than
 //        if Meteor.client.loginWithToken(nil) == false {
@@ -301,7 +301,7 @@ public class Meteor {
      - parameter viewController:    A view controller from which to launch the OAuth modal dialog
      */
     
-    public static func loginWithTwitter<T: UIViewController>(viewController: T) {
+    open static func loginWithTwitter<T: UIViewController>(_ viewController: T) {
         Meteor.loginWithService("twitter", clientId: "", viewController: viewController)
     }
     
@@ -312,7 +312,7 @@ public class Meteor {
      - parameter clientId:          The apps client id, provided by the service (Facebook, Google, etc.)
      */
     
-    public static func loginWithFacebook<T: UIViewController>(clientId: String, viewController: T) {
+    open static func loginWithFacebook<T: UIViewController>(_ clientId: String, viewController: T) {
         Meteor.loginWithService("facebook", clientId: clientId, viewController: viewController)
     }
     
@@ -323,7 +323,7 @@ public class Meteor {
      - parameter clientId:          The apps client id, provided by the service (Facebook, Google, etc.)
      */
     
-    public static func loginWithGithub<T: UIViewController>(clientId: String, viewController: T) {
+    open static func loginWithGithub<T: UIViewController>(_ clientId: String, viewController: T) {
         Meteor.loginWithService("github", clientId: clientId, viewController: viewController)
     }
 
@@ -334,7 +334,7 @@ public class Meteor {
      - parameter clientId:          The apps client id, provided by the service (Facebook, Google, etc.)
      */
     
-    public static func loginWithGoogle<T: UIViewController>(clientId: String, viewController: T) {
+    open static func loginWithGoogle<T: UIViewController>(_ clientId: String, viewController: T) {
         Meteor.loginWithService("google", clientId: clientId, viewController: viewController)
     }
     
@@ -344,7 +344,7 @@ public class Meteor {
     - parameter callback: An optional closure to be executed after the client has logged out
     */
     
-    public static func logout(callback:DDPMethodCallback?) {
+    open static func logout(_ callback:DDPMethodCallback?) {
         client.logout(callback)
     }
     
@@ -352,7 +352,7 @@ public class Meteor {
     Logs a user out of the server
     */
     
-    public static func logout() {
+    open static func logout() {
         client.logout()
     }
     
@@ -360,10 +360,10 @@ public class Meteor {
     Meteor.Client is a subclass of DDPClient that facilitates interaction with the MeteorCollection class
     */
     
-    public class Client: DDPClient {
+    open class Client: DDPClient {
         
         typealias SubscriptionCallback = () -> ()
-        let notifications = NSNotificationCenter.defaultCenter()
+        let notifications = NotificationCenter.default
         
         public convenience init(url:String, email:String, password:String) {
             self.init()
@@ -378,7 +378,7 @@ public class Meteor {
         - parameter fields:         an optional NSDictionary with the documents properties
         */
         
-        public override func documentWasAdded(collection:String, id:String, fields:NSDictionary?) {
+        open override func documentWasAdded(_ collection:String, id:String, fields:NSDictionary?) {
             if let meteorCollection = Meteor.collections[collection] {
                 meteorCollection.documentWasAdded(collection, id: id, fields: fields)
             }
@@ -394,7 +394,7 @@ public class Meteor {
         - parameter cleared:        an optional array of string property names to delete
         */
         
-        public override func documentWasChanged(collection:String, id:String, fields:NSDictionary?, cleared:[String]?) {
+        open override func documentWasChanged(_ collection:String, id:String, fields:NSDictionary?, cleared:[String]?) {
             if let meteorCollection = Meteor.collections[collection] {
                 meteorCollection.documentWasChanged(collection, id: id, fields: fields, cleared: cleared)
             }
@@ -408,7 +408,7 @@ public class Meteor {
         - parameter id:             the string unique id that identifies the document on the server
         */
         
-        public override func documentWasRemoved(collection:String, id:String) {
+        open override func documentWasRemoved(_ collection:String, id:String) {
             if let meteorCollection = Meteor.collections[collection] {
                 meteorCollection.documentWasRemoved(collection, id: id)
             }

--- a/SwiftDDP/Meteor.swift
+++ b/SwiftDDP/Meteor.swift
@@ -77,7 +77,7 @@ open class Meteor {
     - parameter params:     An object containing method arguments, if any.
     */
     
-    open static func subscribe(_ name:String, params:[AnyObject]) -> String { return client.sub(name, params:params) }
+    open static func subscribe(_ name:String, params:[Any]) -> String { return client.sub(name, params:params) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -89,7 +89,7 @@ open class Meteor {
     - parameter callback:   The closure to be executed when the server sends a 'ready' message.
     */
     
-    open static func subscribe(_ name:String, params:[AnyObject]?, callback: DDPCallback?) -> String { return client.sub(name, params:params, callback:callback) }
+    open static func subscribe(_ name:String, params:[Any]?, callback: DDPCallback?) -> String { return client.sub(name, params:params, callback:callback) }
     
     /**
     Sends a subscription request to the server. If a callback is passed, the callback asynchronously
@@ -137,8 +137,8 @@ open class Meteor {
     - parameter callback:   The closure to be executed when the method has been executed
     */
     
-    open static func call(_ name:String, params:[AnyObject]?, callback:DDPMethodCallback?) -> String? {
-        return client.method(name, params: params as AnyObject?, callback: callback)
+    open static func call(_ name:String, params:[Any]?, callback:DDPMethodCallback?) -> String? {
+        return client.method(name, params: params, callback: callback)
     }
     
     /**

--- a/SwiftDDP/MeteorCollection.swift
+++ b/SwiftDDP/MeteorCollection.swift
@@ -172,7 +172,7 @@ open class MeteorCollection<T:MeteorDocument>: AbstractCollection {
     - parameter operation:      a dictionary containing a Mongo selector and a json object
     */
     
-    open func update(_ document: T, withMongoOperation operation: [String:AnyObject]) {
+    open func update(_ document: T, withMongoOperation operation: [String:Any]) {
         let originalDocument = documents[document._id]
         
         documents[document._id] = document

--- a/SwiftDDP/MeteorDocument.swift
+++ b/SwiftDDP/MeteorDocument.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-public class MeteorDocument: NSObject {
+open class MeteorDocument: NSObject {
     
     var _id:String
     
@@ -29,14 +29,14 @@ public class MeteorDocument: NSObject {
         super.init()
         if let properties = fields {
             for (key,value) in properties  {
-                if !value.isEqual(NSNull()) {
+                if !(value as AnyObject).isEqual(NSNull()) {
                     self.setValue(value, forKey: key as! String)
                 }
             }
         }
     }
     
-    public func update(fields: NSDictionary?, cleared: [String]?) {
+    open func update(_ fields: NSDictionary?, cleared: [String]?) {
         if let properties = fields {
             for (key,value) in properties  {
                 print("Key: \(key), Value: \(value)")
@@ -67,15 +67,15 @@ public class MeteorDocument: NSObject {
     /*
     This method should be public so users of this library can override it for parsing their variables in their MeteorDocument object when having structs and such in their Document.
     */
-    public func fields() -> NSDictionary {
+    open func fields() -> NSDictionary {
         let fieldsDict = NSMutableDictionary()
         let properties = propertyNames()
         
         for name in properties {
-            if var value = self.valueForKey(name) {
+            if var value = self.value(forKey: name) {
                 
-                if value as? NSDate != nil {
-                    value = EJSON.convertToEJSONDate(value as! NSDate)
+                if value as? Date != nil {
+                    value = EJSON.convertToEJSONDate(value as! Date)
                 }
                 
                 fieldsDict.setValue(value, forKey: name)

--- a/SwiftDDP/MeteorDocument.swift
+++ b/SwiftDDP/MeteorDocument.swift
@@ -29,7 +29,7 @@ open class MeteorDocument: NSObject {
         super.init()
         if let properties = fields {
             for (key,value) in properties  {
-                if !(value as AnyObject).isEqual(NSNull()) {
+                if !(value is NSNull) {
                     self.setValue(value, forKey: key as! String)
                 }
             }

--- a/SwiftDDPTests/Data.swift
+++ b/SwiftDDPTests/Data.swift
@@ -19,8 +19,8 @@ class Document: MeteorDocument {
 
 //let url = "ws://swiftddp.meteor.com/websocket"
 let url = "ws://localhost:3000/websocket"
-let user = "test@user.com"
-let pass = "swiftddp"
+let user = "mjgaylord@gmail.com"
+let pass = "mjgaylord123"
 
 let ready = DDPMessage(message: "{\"msg\":\"ready\", \"subs\":[\"AllStates\"]}")
 let nosub = DDPMessage(message: ["msg":"nosub", "id":"AllStates"])

--- a/SwiftDDPTests/SwiftDDP.swift
+++ b/SwiftDDPTests/SwiftDDP.swift
@@ -176,7 +176,7 @@ class DDPServerTests:QuickSpec {
                 expect(testResult).toEventuallyNot(beNil(), timeout:5)
                 expect(testSession).toEventuallyNot(beNil(), timeout:5)
                 
-                let userDefaultsToken = client.userData.objectForKey("DDP_TOKEN") as! String
+                let userDefaultsToken = client.userData.object(forKey: "DDP_TOKEN") as! String
                 let resultToken = testResult["token"] as! String
                 
                 expect(userDefaultsToken).toEventually(equal(resultToken), timeout:5)
@@ -204,7 +204,8 @@ class DDPServerTests:QuickSpec {
                 
                 // the tuple that holds the subscription data in the client should be updated to reflect that the
                 // subscription is ready
-                expect(client.findSubscription("test-collection2")?.ready).toEventually(beTrue(), timeout:5)
+                let subscriptionID = client.findSubscription("test-collection2")
+                expect(client.subscriptionReady("test-collection2")).toEventually(beTrue(), timeout:5)
                 
                 // test that the data is returned from the server
                 expect(added.count).toEventually(equal(1), timeout:5)


### PR DESCRIPTION
I haven't tested it 100% yet, but for anyone that is interested in taking a look, here is a pull request for the Swift 3 upgrade. It seems to be working okay in my app. 

The biggest changes aside from the Convert to Swift 3 tool in XCode was to change `AnyObject` to `Any` in order to accept struct values. This might break ObjC implementations, so HBD.

I also added some `@discardableResult` annotations to some of the methods to suppress warnings in XCode for not using the result of various methods.