### PR TITLE
Remove force-unwrap of self.user()

### DIFF
--- a/SwiftDDP/DDPExtensions.swift
+++ b/SwiftDDP/DDPExtensions.swift
@@ -463,9 +463,9 @@ extension DDPClient {
         method("logout", params: nil) { result, error in
                 if (error == nil) {
                     self.userMainQueue.addOperation() {
-                        let user = self.user()!
-                        if let _ = self.delegate {
-                            self.delegate!.ddpUserDidLogout(user)
+                        if let user = self.user(),
+                            let delegate = self.delegate {
+                            delegate.ddpUserDidLogout(user)
                         }
                         self.resetUserData()
                         NotificationCenter.default.post(name: Notification.Name(rawValue: DDP_USER_DID_LOGOUT), object: nil)


### PR DESCRIPTION
Duplicate calls that happen in quick succession of `func logout(:)` result in a crash because `self.user()!` is force-unwrapped. Checking for existence of the user object seems to prevent the crash.