### PR TITLE
Update SwiftDDP.podspec

### DIFF
--- a/SwiftDDP.podspec
+++ b/SwiftDDP.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/*.swift'
 
   s.dependency 'CryptoSwift'
-  s.dependency 'SwiftWebSocket',:git => 'https://github.com/tidwall/SwiftWebSocket.git', :branch => 'master'
+  s.dependency 'SwiftWebSocket'
   s.dependency 'XCGLogger'
 
 end


### PR DESCRIPTION
Removing the address for SwiftWebSocket resolved the 'unsupported version requirements' error.