### PR TITLE
Bugfix:  'self' may be nil when code is executed in a background thread

### DIFF
--- a/Sources/DDPClient.swift
+++ b/Sources/DDPClient.swift
@@ -386,7 +386,14 @@ open class DDPClient: NSObject {
         let message = ["msg":"sub", "name":name, "id":id] as NSMutableDictionary
         if let p = params { message["params"] = p }
         userBackground.addOperation() {
-            self.sendMessage(message)
+            [weak self] in
+            
+            if let strongSelf = self
+            {
+                strongSelf.sendMessage(message)
+            } else {
+                log.error("Ignored message - client was already destroyed")
+            }
         }
         return id
     }


### PR DESCRIPTION
After using SwiftDDP in production with ~5k users I started to receive crash reports via iTunes connect as follows:

```
Exception Type:  EXC_BREAKPOINT (SIGTRAP)
Exception Codes: 0x0000000000000001, 0x00000001020fdd70
Termination Signal: Trace/BPT trap: 5
Termination Reason: Namespace SIGNAL, Code 0x5
Terminating Process: exc handler [489]
Triggered by Thread:  9

Thread 9 name:
Thread 9 Crashed:
0   MYAPP                       	0x00000001020fdd70 DDPClient.sendMessage(_:) + 448 (DDPClient.swift:344)
1   MYAPP                       	0x00000001021065d0 partial apply for closure #1 in DDPClient.sub(_:name:params:callback:) + 24 (DDPClient.swift:390)
2   MYAPP                       	0x00000001020ce1e4 thunk for @escaping @callee_guaranteed () -> () + 28 (<compiler-generated>:0)
3   Foundation                    	0x0000000188584f68 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 16 (NSOperation.m:1559)
4   Foundation                    	0x0000000188491420 -[NSBlockOperation main] + 72 (NSOperation.m:1578)
5   Foundation                    	0x0000000188490908 -[__NSOperationInternal _start:] + 740 (NSOperation.m:907)
6   Foundation                    	0x0000000188586cec __NSOQSchedule_f + 272 (NSOperation.m:2165)
7   libdispatch.dylib             	0x00000001875421cc _dispatch_block_async_invoke2 + 104 (queue.c:518)
8   libdispatch.dylib             	0x00000001875617d4 _dispatch_client_callout + 16 (object.m:511)
9   libdispatch.dylib             	0x0000000187538c34 _dispatch_continuation_pop$VARIANT$armv81 + 404 (inline_internal.h:2441)
10  libdispatch.dylib             	0x0000000187538314 _dispatch_async_redirect_invoke + 592 (queue.c:796)
11  libdispatch.dylib             	0x00000001875449d4 _dispatch_root_queue_drain + 340 (inline_internal.h:2482)
12  libdispatch.dylib             	0x0000000187545248 _dispatch_worker_thread2 + 116 (queue.c:6072)
13  libsystem_pthread.dylib       	0x00000001877411b4 _pthread_wqthread + 464 (pthread.c:2361)
14  libsystem_pthread.dylib       	0x0000000187743cd4 start_wqthread + 4
```